### PR TITLE
Handle Dynamic Fields

### DIFF
--- a/fields.py
+++ b/fields.py
@@ -22,6 +22,17 @@ class Field(dict):
         for key, value in self.DEFAULT_DRF_FIELD_KWARGS.items():
             self.setdefault(key, value)
 
+    def add_representation(self, condition, representation):
+        if not self.get('representations'):
+            self['representations'] = {}
+
+        self['representations'][condition] = representation
+
+    def update_representations(self, representations):
+        if not self.get('representations'):
+            self['representations'] = {}
+
+        self['representations'].update(**representations)
 
 class Fields(dict):
     """
@@ -54,6 +65,20 @@ class Fields(dict):
             return
 
         self[self.get_field_name(field)] = field
+
+    def add_representation(self, field_name, condition, representation, overwrite=False):
+        if not (field_name and condition and representation):
+            return
+
+        if not field_name in self:
+            self.add(Field(field_name=field_name))
+
+        field = self.find(field_name)
+
+        if not overwrite and condition in field.get('representations', {}):
+            return
+
+        field.add_representation(condition, representation)
 
     def find(self, field_name):
         return self[field_name]

--- a/fields.py
+++ b/fields.py
@@ -22,17 +22,14 @@ class Field(dict):
         for key, value in self.DEFAULT_DRF_FIELD_KWARGS.items():
             self.setdefault(key, value)
 
-    def add_representation(self, condition, representation):
-        if not self.get('representations'):
-            self['representations'] = {}
+        self.representations = {}
 
-        self['representations'][condition] = representation
+    def add_representation(self, cond, representation):
+        self.representations[cond] = representation
 
     def update_representations(self, representations):
-        if not self.get('representations'):
-            self['representations'] = {}
+        self.representations.update(**representations)
 
-        self['representations'].update(**representations)
 
 class Fields(dict):
     """
@@ -77,7 +74,7 @@ class Fields(dict):
 
         field = self.find(field_name)
 
-        if not overwrite and condition in field.get('representations', {}):
+        if not overwrite and condition in field.representations:
             return
 
         field.add_representation(condition, representation)
@@ -162,7 +159,7 @@ class Fields(dict):
             return dict(
                 (condition, field_description(representation))
                 for condition, representation
-                in field.get('representations', {}).iteritems()
+                in field.representations.iteritems()
                 )
 
         def describe_field(field):

--- a/fields.py
+++ b/fields.py
@@ -41,6 +41,8 @@ class Fields(dict):
 
     ADDED_FMT_STR = "'{}': {}\n"
     REMOVED_FMT_STR = "- '{}': {}\n"
+    ADDED_DYNAMIC_STR = "'{}'\n\t'{}': {}\n"
+    REMOVED_DYNAMIC_STR = "'- {}'\n\t'{}': {}\n"
 
     @classmethod
     def get_field_name(cls, field):
@@ -92,6 +94,22 @@ class Fields(dict):
             return colored(self.REMOVED_FMT_STR.format(key, val),
                            consts.Colours.REMOVED)
 
+        def fmt_added_dynamic(condition, key, val):
+            return colored(self.ADDED_DYNAMIC_STR.format(condition, key, val),
+                           consts.Colours.ADDED)
+
+        def fmt_removed_dynamic(condition, key, val):
+            return colored(self.REMOVED_DYNAMIC_STR.format(condition, key, val),
+                           consts.Colours.REMOVED)
+
+        def fmt_representations(field, representations, format_function):
+            output = ''
+
+            for key, val in representations.iteritems():
+                output += format_function(key, field, val)
+
+            return output
+
         current = self.as_dict()
         previous = base.as_dict()
         keys = set(current.keys()).union(previous.keys())
@@ -102,12 +120,19 @@ class Fields(dict):
                 if current[key] == previous[key]:
                     continue
 
-                output += fmt_removed(key, previous[key])
-                output += fmt_added(key, current[key])
+                output += fmt_removed(key, previous[key]['description'])
+                output += fmt_representations(key, previous[key]['representations'], fmt_removed_dynamic)
+
+                output += fmt_added(key, current[key]['description'])
+                output += fmt_representations(key,current[key]['representations'], fmt_added_dynamic)
+
             elif key in current:
-                output += fmt_added(key, current[key])
+                output += fmt_added(key, current[key]['description'])
+                output += fmt_representations(key, current[key]['representations'], fmt_added_dynamic)
+
             else:
-                output += fmt_removed(key, previous[key])
+                output += fmt_removed(key, previous[key]['description'])
+                output += fmt_representations(key, previous[key]['representations'], fmt_removed_dynamic)
 
         return output
 
@@ -124,16 +149,30 @@ class Fields(dict):
 
             return '[{}]'.format(field_type) if field_type else ''
 
-        def describe_field(field):
+        def field_description(field):
             checked_properties = ['required', 'read_only']
             properties = [prop
                           for prop in checked_properties
                           if field[prop]]
             field_type_desc = describe_field_type(field)
             properties_desc = ', '.join(properties)
-            description = ' '.join([field_type_desc, properties_desc]).strip()
+            return ' '.join([field_type_desc, properties_desc]).strip()
 
-            return field['field_name'], description
+        def field_representations(field):
+            return dict(
+                (condition, field_description(representation))
+                for condition, representation
+                in field.get('representations', {}).iteritems()
+                )
+
+        def describe_field(field):
+            key = field['field_name']
+            value = {
+                'description': field_description(field),
+                'representations': field_representations(field)
+            }
+
+            return key, value
 
         return dict(
             describe_field(field)

--- a/git.py
+++ b/git.py
@@ -46,6 +46,6 @@ def get_changed_files(branch='master'):
 
     process = checked_command(["git", "diff", "--name-only", branch, "apiv2/serializers"])
 
-    return [re.sub('sigma/', '', x) for x in process.stdout.read().split()]
+    return [re.sub('sigma/', './', x) for x in process.stdout.read().split()]
 
 

--- a/parser.py
+++ b/parser.py
@@ -192,7 +192,7 @@ class FieldFinder(object):
             raise
 
     def augment_field(self, previous, current):
-        previous.update_representations(current.get('representations', {}))
+        previous.update_representations(current.representations)
 
         return previous
 

--- a/parser.py
+++ b/parser.py
@@ -193,7 +193,7 @@ class FieldFinder(object):
 
     def augment_field(self, previous, current):
         # TODO: ???
-        raise Exception
+        pass
 
     def find_serializer_fields(self, serializer_name):
         nodes = self.serializer_registry.nodes
@@ -240,11 +240,11 @@ class FieldFinder(object):
             dynamic_fields = Resolver.init_method(node)
             for field in dynamic_fields:
                 if field not in fields:
-                    fields.add(field)
+                    fields.add(dynamic_fields[field])
                     continue
 
-                previous_field = fields[field['field_name']]
-                augmented_field = self.augment_field(previous_field, field)
+                previous_field = fields[field]
+                augmented_field = self.augment_field(previous_field, dynamic_fields[field])
                 fields.add(augmented_field, overwrite=True)
 
         self.memo_dict[serializer_name] = fields

--- a/resolver.py
+++ b/resolver.py
@@ -45,7 +45,8 @@ class Resolver(object):
         if hasattr(target, 'id'):
             lhs = target.id
         else:
-            # This is probably the wrong way to represent this
+            # This is a Subscript node and should probably be represented
+            # in a better way to demonstrate that.
             lhs = Resolver.resolve(target.slice)
 
         rhs = node.value
@@ -152,6 +153,8 @@ class Resolver(object):
         return (
             isinstance(node, ast.If) and
             # TODO: Might need to support more test types. This isn't flexible.
+            # Currently it only returns true when testing a variable name or
+            # an unary operation like `if some_var` or `if not some_var`.
             (isinstance(node.test, ast.Name) or isinstance(node.test, ast.UnaryOp))
         )
     @staticmethod


### PR DESCRIPTION
Parse fields that are added or removed dynamically via include/exclude/expand filters.

Fixes issue #1.

**Note: This is still a WIP.** Submitting for visibility and to share code during the Hackathon.

**Known Issues**

* The `dynamic_fields` property only includes Serializers that have explicitly defined include/exclude/expand filters and not the subclasses that inherit these filters. As a result, 
`Resolver.init_method` is not called for the missed Serializers. Added a workaround to search a single level of inheritance for dynamic fields to partially address this.

* The Resolver doesn't handle all ast classes at the moment and in some cases errors are raised when attempting to resolve instances of those classes. There might also be some missing conditional checks in the `init_method` that would help skip over these cases.

* This doesn't yet support dynamically deleting fields (`if not include_filter: del self.fields['some_field']`). It also doesn't handle changing the attributes of a field (`if some_condition: self.fields['some_field'].required = False`).